### PR TITLE
fix: Pre-bundle text encoder to prevent HF rate limiting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,19 @@ RUN mkdir -p /app/MODEL_DIR && \
     python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id='Lightricks/LTX-Video', filename='ltxv-13b-0.9.7-distilled.safetensors', local_dir='/app/MODEL_DIR', local_dir_use_symlinks=False, repo_type='model')" && \
     python -c "from huggingface_hub import hf_hub_download; hf_hub_download(repo_id='Lightricks/LTX-Video', filename='ltxv-spatial-upscaler-0.9.7.safetensors', local_dir='/app/MODEL_DIR', local_dir_use_symlinks=False, repo_type='model')"
 
+# Download the PixArt-alpha text encoder model components
+# These are specified by text_encoder_model_name_or_path in the LTX config.
+# We use snapshot_download to get the entire model repo, ensuring all necessary files
+# (like config.json, model weights, tokenizer files, and subfolders) are present.
+# The target directory name is sanitized to be a valid directory name.
+RUN python -c "from huggingface_hub import snapshot_download; import os; \
+    repo_id='PixArt-alpha/PixArt-XL-2-1024-MS'; \
+    sanitized_repo_id = repo_id.replace('/', '_'); \
+    local_dir=os.path.join('/app/text_encoder_models_cache', sanitized_repo_id); \
+    os.makedirs(local_dir, exist_ok=True); \
+    snapshot_download(repo_id=repo_id, local_dir=local_dir, local_dir_use_symlinks=False, \
+                      allow_patterns=['*.json', '*.safetensors', '*.bin', '*.md', 'spiece.model'])"
+
 # Copy the rest of the application code
 # This includes inference.py, the ltx_video module, configs, etc.
 COPY . .

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# LTX-Video  
+# LTX-Video
 
 This is the official repository for LTX-Video.
 
@@ -216,7 +216,7 @@ The following files have been added or modified:
 -   `handler.py`: The entry point for RunPod Serverless workers. It processes incoming job requests,
     handles image URL inputs, manages conditioning parameters (keyframes), and invokes the
     LTX Video inference pipeline using the `ltxv-13b-0.9.7-distilled.safetensors` model by default.
--   `Dockerfile`: Defines the container image with all necessary dependencies. **The primary models (`ltxv-13b-0.9.7-distilled.safetensors` and `ltxv-spatial-upscaler-0.9.7.safetensors`) are pre-downloaded and included in this image.** This increases the overall image size but significantly improves cold start times for new serverless worker instances by eliminating on-demand model downloads.
+-   `Dockerfile`: Defines the container image with all necessary dependencies. **The primary LTX Video models (`ltxv-13b-0.9.7-distilled.safetensors` and `ltxv-spatial-upscaler-0.9.7.safetensors`), as well as the required `PixArt-alpha/PixArt-XL-2-1024-MS` text encoder components, are pre-downloaded and included in this image.** This increases the overall image size but significantly improves cold start times and reliability by eliminating on-demand model downloads during worker initialization.
 -   `requirements.txt`: A list of Python dependencies automatically generated from `pyproject.toml`,
     used by the `Dockerfile` for setting up the environment.
 -   `inference.py`: Modified to accept image URLs as input for conditioning frames.


### PR DESCRIPTION
This commit resolves an issue where runtime fetching of the PixArt-alpha/PixArt-XL-2-1024-MS text encoder components was causing Hugging Face API rate limit errors (HTTP 429).

Changes include:
- Modified `Dockerfile`: Added RUN instructions to pre-download and bundle the `PixArt-alpha/PixArt-XL-2-1024-MS` text encoder and tokenizer components into the Docker image. This ensures these files are locally available within the container.
- Modified `inference.py`: Updated the text encoder loading logic in `create_ltx_video_pipeline` to prioritize using these pre-downloaded local files. It now uses `local_files_only=True` when loading from the local path to prevent any outbound Hugging Face API calls for these components. A fallback to download (if local files are somehow missing) is retained but should ideally not be triggered.
- Updated `README.md`: Clarified in the RunPod Serverless deployment section that the text encoder components are now also pre-bundled, improving reliability and cold start times.

These changes ensure that all critical model components (LTX main model, upscaler, and text encoder) are included in the Docker image, mitigating runtime download failures due to external API limits.